### PR TITLE
Implement Caddy as a reverse proxy to the Rust and PHP backends

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -4,3 +4,4 @@ DB_PASSWORD=""
 DB_DATABASE="OverseerV2"
 OVERSEER_ROOT="/php/"
 OVERSEER_PHP_SESSIONS_ROOT="/.session/"
+SITE_HOSTNAME=v2.overseerreboot.xyz

--- a/README.md
+++ b/README.md
@@ -18,10 +18,12 @@ https://youtu.be/sNQw6eO1aJ0
 
 ## Dockerized Setup
 
-1. Install Docker (for dev work, you can also look at Docker Desktop)
+1. Install [Docker](https://www.docker.com/) (for dev work, you can also look at installing [Docker Desktop](https://www.docker.com/products/docker-desktop/) to have the containers in an easy-to-view GUI)
 2. Copy `.env.dist` to `.env`, and fill up the credentials appropriately
 3. Run the following command in the base of this repository: `docker compose --profile dev up -d --build`
-4. Wait for the build to finish
-5. The website should now be accessible in `http://localhost:9000`, and the database should be accessible
+4. Wait for the build to finish. This may take a while depending on how fast your internet connection and computer are. An initial build is expected to take about 5 minutes.
+5. The website should now be accessible in `http://localhost:8000`, with the PHP side directly accessible in `http://localhost:9000`, the Rust side directly accessible in `http://localhost:8010`, and the MySQL database directly accessible via `localhost:3306`.
 
 > If you want to run the website without building again in the future, do `docker compose --profile dev up -d` instead.
+
+> WARNING: Rebuilds might fail if the Rust container is running. This is due to the container still holding the lock for the Rust project, making the Docker build agent unable to build the project. If this is happening to you, turn the Rust container off and try again.

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -8,15 +8,13 @@
 		}
 	}
 
-	# TODO: Make this Regular Expression easily editable from the Rust side so this doesn't need
-	#       to be edited every time we migrate something from PHP to Rust
-	# https://regexr.com/8fsh2
-	@rust_routes path_regexp ^\/((sse)|(overview)|(character)|(waste-time))
-	reverse_proxy @rust_routes {$RUST_URI} {
+	@php_routes expression {path}.endsWith(".php") || {path} == "/"
+
+	reverse_proxy @php_routes {$PHP_URI} {
 		header_up X-Real-IP {client_ip}
 	}
 
-	reverse_proxy {$PHP_URI} {
+	reverse_proxy {$RUST_URI} {
 		header_up X-Real-IP {client_ip}
 	}
 }

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -9,8 +9,13 @@
 	}
 
 	@php_routes expression {path}.endsWith(".php") || {path} == "/"
+	@static_routes expression {path}.endsWith(".css") || {path}.endsWith(".js") || {path}.endsWith(".png") || {path}.endsWith(".jpg") || {path}.endsWith(".gif") || {path}.endsWith(".svg") || {path}.endsWith(".ico") || {path}.endsWith(".ttf")
 
 	reverse_proxy @php_routes {$PHP_URI} {
+		header_up X-Real-IP {client_ip}
+	}
+
+	reverse_proxy @static_routes {$PHP_URI} {
 		header_up X-Real-IP {client_ip}
 	}
 

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -1,0 +1,22 @@
+{$SITE_HOSTNAME:http://localhost:8000} {
+	log {
+		format json
+		output file /var/log/access.log {
+			roll_size 2gb
+			roll_keep 5
+			roll_keep_for 720h
+		}
+	}
+
+	# TODO: Make this Regular Expression easily editable from the Rust side so this doesn't need
+	#       to be edited every time we migrate something from PHP to Rust
+	# https://regexr.com/8fsh2
+	@rust_routes path_regexp ^\/((sse)|(overview)|(character)|(waste-time))
+	reverse_proxy @rust_routes {$RUST_URI} {
+		header_up X-Real-IP {client_ip}
+	}
+
+	reverse_proxy {$PHP_URI} {
+		header_up X-Real-IP {client_ip}
+	}
+}

--- a/config/caddy/Dockerfile
+++ b/config/caddy/Dockerfile
@@ -1,0 +1,10 @@
+# FROM caddy:2.10.0-builder-alpine AS builder
+
+# RUN xcaddy build \
+#     --with github.com/caddy-dns/cloudflare \
+#     --with github.com/WeidiDeng/caddy-cloudflare-ip
+
+FROM caddy:2.10-alpine
+# COPY --from=builder /usr/bin/caddy /usr/bin/caddy
+
+# TODO: Enable Cloudflare DNS support

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   database:
     &database
+    restart: always
     profiles:
       - prod
     build:
@@ -15,6 +16,7 @@ services:
   
   database-dev:
     <<: *database
+    restart: on-failure
     profiles:
       - dev
     ports:
@@ -24,16 +26,13 @@ services:
     &php
     profiles:
       - prod
-    restart: on-failure
+    restart: always
     build:
       dockerfile: ./config/php/Dockerfile.prod
     volumes:
       - session_data:/var/www/sessions/
     env_file:
       - .env
-    ports:
-      - 80:80
-      - 443:443
     depends_on:
       - database
   
@@ -56,7 +55,7 @@ services:
     &rust
     profiles:
       - prod
-    restart: on-failure
+    restart: always
     build:
       dockerfile: ./config/rust/Dockerfile.prod
     env_file:
@@ -66,9 +65,6 @@ services:
       - OVERSEER_ROOT=/php/
     volumes:
       - session_data:${OVERSEER_PHP_SESSIONS_ROOT}
-    ports:
-      - 80:80
-      - 443:443
     depends_on:
       - database
   
@@ -90,6 +86,48 @@ services:
     depends_on:
       - database-dev
 
+  proxy:
+    &proxy
+    profiles:
+      - prod
+    image: caddy:2.10-alpine
+    restart: always
+    build:
+      context: ./config/caddy
+    cap_add:
+      - NET_ADMIN
+    ports:
+      - '80:80'
+      - '443:443'
+      - '443:443/udp'
+    volumes:
+      - ./config/caddy/Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      - SITE_HOSTNAME=${SITE_HOSTNAME}
+      - RUST_URI=http://rust:8010
+      - PHP_URI=http://php:9000
+    depends_on:
+      - php
+      - rust
+
+  proxy-dev:
+    <<: *proxy
+    profiles:
+      - dev
+    environment:
+      - SITE_HOSTNAME=http://localhost:8000
+      - RUST_URI=http://rust-dev:8010
+      - PHP_URI=http://php-dev:9000
+    ports:
+      - 8000:8000
+    depends_on:
+      - php-dev
+      - rust-dev
+
 volumes:
   db_data:
   session_data:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
This PR adds [Caddy](https://caddyserver.com) as the reverse proxy for handling incoming requests.

For the dev profile, this should host the site at http://localhost:8000

For the prod profile, this should host the site at whatever `SITE_HOSTNAME` is set to. Caddy should automatically configure HTTPS certificates and should automatically host the site in HTTPS.