### PR TITLE
Actually generate the debuglog file

### DIFF
--- a/config/php/Dockerfile.prod
+++ b/config/php/Dockerfile.prod
@@ -19,6 +19,7 @@ RUN echo "ServerName localhost:9000" >> /etc/apache2/apache2.conf
 
 # Copy project files
 COPY ./php/ /var/www/html/
+RUN touch /var/www/html/devtools/debuglog.txt
 RUN chown -R www-data /var/www/html/
 
 # Run setup


### PR DESCRIPTION
Been getting issues that look like the following:

```
Warning: fopen(/var/www/html/includes/../devtools/debuglog.txt): Failed to open stream: Permission denied in /var/www/html/includes/global_functions.php on line 841
Couldn't open debug log at /var/www/html/includes/../devtools/debuglog.txt!
```

This should generate the appropriate text file, and the www-data user should have appropriate access to write and read from it.