### PR TITLE
Create PHPMyAdmin container

### DIFF
--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -12,7 +12,9 @@
 	@static_routes expression {path}.endsWith(".css") || {path}.endsWith(".js") || {path}.endsWith(".png") || {path}.endsWith(".jpg") || {path}.endsWith(".gif") || {path}.endsWith(".svg") || {path}.endsWith(".ico") || {path}.endsWith(".ttf")
 
 	basic_auth /phpmyadmin/* {
-		overseer $2a$14$hOVtJYq2ncTgLJXTMt4vIeGMRfPrDamnYx.l9JEf6NcDCbUnOcJ2K
+		# By default, this password is 'hunter2'. This WILL be changed
+		# via environment variables in the production environment.
+		overseer {$PHPMYADMIN_AUTH:$2a$14$hamTMPfXzh6y14gNyeFShOXB.Vkylc4x40GttYhTVtWu5fp1iWyEW}
 	}
 
 	handle_path /phpmyadmin/* {

--- a/config/caddy/Caddyfile
+++ b/config/caddy/Caddyfile
@@ -11,6 +11,16 @@
 	@php_routes expression {path}.endsWith(".php") || {path} == "/"
 	@static_routes expression {path}.endsWith(".css") || {path}.endsWith(".js") || {path}.endsWith(".png") || {path}.endsWith(".jpg") || {path}.endsWith(".gif") || {path}.endsWith(".svg") || {path}.endsWith(".ico") || {path}.endsWith(".ttf")
 
+	basic_auth /phpmyadmin/* {
+		overseer $2a$14$hOVtJYq2ncTgLJXTMt4vIeGMRfPrDamnYx.l9JEf6NcDCbUnOcJ2K
+	}
+
+	handle_path /phpmyadmin/* {
+		reverse_proxy {$PHPMYADMIN_URI} {
+			header_up X-Real-IP {client_ip}
+		}
+	}
+
 	reverse_proxy @php_routes {$PHP_URI} {
 		header_up X-Real-IP {client_ip}
 	}

--- a/config/myadmin/Dockerfile
+++ b/config/myadmin/Dockerfile
@@ -1,0 +1,1 @@
+FROM phpmyadmin:5.2.2-apache

--- a/config/myadmin/config.user.inc.php
+++ b/config/myadmin/config.user.inc.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * phpMyAdmin sample configuration, you can use it as base for
+ * manual configuration. For easier setup you can use setup/
+ *
+ * All directives are explained in documentation in the doc/ folder
+ * or at <https://docs.phpmyadmin.net/>.
+ */
+
+declare(strict_types=1);
+
+$DEV_MODE = isset($_ENV['DEV_MODE']) && $_ENV['DEV_MODE'] === 'true';
+
+/**
+ * This is needed for cookie based authentication to encrypt the cookie.
+ * Needs to be a 32-bytes long string of random bytes. See FAQ 2.10.
+ */
+if (!$DEV_MODE) {
+    $cfg['blowfish_secret'] = sodium_hex2bin(
+        $_ENV['BLOWFISH_SECRET'] ?? 'f9e22385f1bc43c9884f141e84f76d2049591a6916764735873611f7b6fd30b8'
+    );
+}
+
+/**
+ * Servers configuration
+ */
+$i = 0;
+
+/**
+ * First server
+ */
+$i++;
+/* Authentication type */
+if (!$DEV_MODE) {
+    $cfg['Servers'][$i]['auth_type'] = 'cookie';
+    /* Server parameters */
+    $cfg['Servers'][$i]['host'] = $_ENV['PMA_HOST'];
+    $cfg['Servers'][$i]['compress'] = false;
+    $cfg['Servers'][$i]['AllowNoPassword'] = false;
+}
+
+/**
+ * phpMyAdmin configuration storage settings.
+ */
+
+/* User used to manipulate with storage */
+// $cfg['Servers'][$i]['controlhost'] = '';
+// $cfg['Servers'][$i]['controlport'] = '';
+// $cfg['Servers'][$i]['controluser'] = 'pma';
+// $cfg['Servers'][$i]['controlpass'] = 'pmapass';
+
+/* Storage database and tables */
+// $cfg['Servers'][$i]['pmadb'] = 'phpmyadmin';
+// $cfg['Servers'][$i]['bookmarktable'] = 'pma__bookmark';
+// $cfg['Servers'][$i]['relation'] = 'pma__relation';
+// $cfg['Servers'][$i]['table_info'] = 'pma__table_info';
+// $cfg['Servers'][$i]['table_coords'] = 'pma__table_coords';
+// $cfg['Servers'][$i]['pdf_pages'] = 'pma__pdf_pages';
+// $cfg['Servers'][$i]['column_info'] = 'pma__column_info';
+// $cfg['Servers'][$i]['history'] = 'pma__history';
+// $cfg['Servers'][$i]['table_uiprefs'] = 'pma__table_uiprefs';
+// $cfg['Servers'][$i]['tracking'] = 'pma__tracking';
+// $cfg['Servers'][$i]['userconfig'] = 'pma__userconfig';
+// $cfg['Servers'][$i]['recent'] = 'pma__recent';
+// $cfg['Servers'][$i]['favorite'] = 'pma__favorite';
+// $cfg['Servers'][$i]['users'] = 'pma__users';
+// $cfg['Servers'][$i]['usergroups'] = 'pma__usergroups';
+// $cfg['Servers'][$i]['navigationhiding'] = 'pma__navigationhiding';
+// $cfg['Servers'][$i]['savedsearches'] = 'pma__savedsearches';
+// $cfg['Servers'][$i]['central_columns'] = 'pma__central_columns';
+// $cfg['Servers'][$i]['designer_settings'] = 'pma__designer_settings';
+// $cfg['Servers'][$i]['export_templates'] = 'pma__export_templates';
+
+/**
+ * End of servers configuration
+ */
+
+/**
+ * Directories for saving/loading files from server
+ */
+// $cfg['UploadDir'] = '';
+// $cfg['SaveDir'] = '';
+
+/**
+ * Whether to display icons or text or both icons and text in table row
+ * action segment. Value can be either of 'icons', 'text' or 'both'.
+ * default = 'both'
+ */
+//$cfg['RowActionType'] = 'icons';
+
+/**
+ * Defines whether a user should be displayed a "show all (records)"
+ * button in browse mode or not.
+ * default = false
+ */
+//$cfg['ShowAll'] = true;
+
+/**
+ * Number of rows displayed when browsing a result set. If the result
+ * set contains more rows, "Previous" and "Next".
+ * Possible values: 25, 50, 100, 250, 500
+ * default = 25
+ */
+//$cfg['MaxRows'] = 50;
+
+/**
+ * Disallow editing of binary fields
+ * valid values are:
+ *   false    allow editing
+ *   'blob'   allow editing except for BLOB fields
+ *   'noblob' disallow editing except for BLOB fields
+ *   'all'    disallow editing
+ * default = 'blob'
+ */
+//$cfg['ProtectBinary'] = false;
+
+/**
+ * Default language to use, if not browser-defined or user-defined
+ * (you find all languages in the locale folder)
+ * uncomment the desired line:
+ * default = 'en'
+ */
+//$cfg['DefaultLang'] = 'en';
+//$cfg['DefaultLang'] = 'de';
+
+/**
+ * How many columns should be used for table display of a database?
+ * (a value larger than 1 results in some information being hidden)
+ * default = 1
+ */
+//$cfg['PropertiesNumColumns'] = 2;
+
+/**
+ * Set to true if you want DB-based query history.If false, this utilizes
+ * JS-routines to display query history (lost by window close)
+ *
+ * This requires configuration storage enabled, see above.
+ * default = false
+ */
+//$cfg['QueryHistoryDB'] = true;
+
+/**
+ * When using DB-based query history, how many entries should be kept?
+ * default = 25
+ */
+//$cfg['QueryHistoryMax'] = 100;
+
+/**
+ * Whether or not to query the user before sending the error report to
+ * the phpMyAdmin team when a JavaScript error occurs
+ *
+ * Available options
+ * ('ask' | 'always' | 'never')
+ * default = 'ask'
+ */
+//$cfg['SendErrorReports'] = 'always';
+
+/**
+ * 'URLQueryEncryption' defines whether phpMyAdmin will encrypt sensitive data from the URL query string.
+ * 'URLQueryEncryptionSecretKey' is a 32 bytes long secret key used to encrypt/decrypt the URL query string.
+ */
+//$cfg['URLQueryEncryption'] = true;
+//$cfg['URLQueryEncryptionSecretKey'] = '';
+
+$cfg['ShowStats'] = true;
+
+/**
+ * You can find more configuration options in the documentation
+ * in the doc/ folder or at <https://docs.phpmyadmin.net/>.
+ */

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - PMA_USER=${DB_USERNAME}
       - PMA_PASSWORD=${DB_PASSWORD}
       - PMA_ABSOLUTE_URI=https://v2.overseerreboot.xyz/phpmyadmin/
+      - BLOWFISH_SECRET=${BLOWFISH_SECRET}
     profiles:
       - prod
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,33 @@ services:
       - MYSQL_DATABASE=${DB_DATABASE}
       - MYSQL_ROOT_PASSWORD=${DB_PASSWORD}
   
+  phpmyadmin:
+    &phpmyadmin
+    build:
+      dockerfile: ./config/myadmin/Dockerfile
+    environment:
+      - PMA_HOST=database
+      - PMA_USER=${DB_USERNAME}
+      - PMA_PASSWORD=${DB_PASSWORD}
+      - PMA_ABSOLUTE_URI=https://v2.overseerreboot.xyz/phpmyadmin/
+    profiles:
+      - prod
+    volumes:
+      - phpmyadmin_sessions:/sessions:rw
+  
+  phpmyadmin-dev:
+    <<: *phpmyadmin
+    environment:
+      - PMA_HOST=database-dev
+      - PMA_USER=${DB_USERNAME}
+      - PMA_PASSWORD=${DB_PASSWORD}
+      - PMA_PORT=3306
+      - PMA_ABSOLUTE_URI=http://localhost:8000/phpmyadmin/
+    profiles:
+      - dev
+    ports:
+      - 8080:80
+  
   php:
     &php
     profiles:
@@ -113,9 +140,11 @@ services:
       - SITE_HOSTNAME=${SITE_HOSTNAME}
       - RUST_URI=http://rust:8010
       - PHP_URI=http://php:9000
+      - PHPMYADMIN_URI=http://phpmyadmin
     depends_on:
       - php
       - rust
+      - phpmyadmin
 
   proxy-dev:
     <<: *proxy
@@ -125,14 +154,17 @@ services:
       - SITE_HOSTNAME=http://localhost:8000
       - RUST_URI=http://rust-dev:8010
       - PHP_URI=http://php-dev:9000
+      - PHPMYADMIN_URI=http://phpmyadmin-dev
     ports:
       - 8000:8000
     depends_on:
       - php-dev
       - rust-dev
+      - phpmyadmin-dev
 
 volumes:
   db_data:
   session_data:
   caddy_data:
   caddy_config:
+  phpmyadmin_sessions:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - prod
     volumes:
       - phpmyadmin_sessions:/sessions:rw
+      - ./config/myadmin/config.user.inc.php:/etc/phpmyadmin/config.user.inc.php
   
   phpmyadmin-dev:
     <<: *phpmyadmin
@@ -51,6 +52,7 @@ services:
       - PMA_PASSWORD=${DB_PASSWORD}
       - PMA_PORT=3306
       - PMA_ABSOLUTE_URI=http://localhost:8000/phpmyadmin/
+      - DEV_MODE=true
     profiles:
       - dev
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,6 +141,7 @@ services:
       - RUST_URI=http://rust:8010
       - PHP_URI=http://php:9000
       - PHPMYADMIN_URI=http://phpmyadmin
+      - PHPMYADMIN_AUTH=${PHPMYADMIN_AUTH}
     depends_on:
       - php
       - rust


### PR DESCRIPTION
This PR creates a PHPMyAdmin container that allows access to the database from a web portal. This will be accessible from `/phpmyadmin/`..

In dev, this would also be accessible in `localhost:8080`. This will not require the HTTP Basic auth to access if accessed directly from this URI. The default HTTP Basic password in the dev profile is set to be `hunter2`.

In prod, MySQL user-based login will be enabled, along with the HTTP Basic password. This password is set from the `PHPMYADMIN_AUTH` environment variable directly, and should **NOT** be left as the default one. The prod profile also allows us to set the `BLOWFISH_SECRET` variable which is used in encryption of the authentication cookie.

The HTTP Basic username for all profiles will always be `overseer`.