### PR TITLE
Chain viewer dependency fix

### DIFF
--- a/config/php/Dockerfile.dev
+++ b/config/php/Dockerfile.dev
@@ -22,9 +22,14 @@ COPY ./config/php/setup.sh /tmp/setup.sh
 
 # Run setup
 RUN apt-get update
-RUN apt-get install -y unzip
+RUN apt-get install -y unzip zlib1g-dev libpng-dev libfreetype6-dev
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install mysqli
+
+# GD needs an extra config line for freetype fonts
+RUN docker-php-ext-configure gd --with-freetype
+RUN docker-php-ext-install gd
+
 RUN composer install
 
 # Copy php.ini


### PR DESCRIPTION
Simple little fix to give the dev env a test drive tonight :).
Chain viewer needs GD to render. This should help.

Added dependencies to the php container:
- zlib, libpng, libfreetype
- php-gd